### PR TITLE
Added HDMI Test in beagle-tester. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 # Source file lists
 SRC_C := $(wildcard src/*.c)
 CLICK_TESTS := $(wildcard click_tests/*.c)
-CPP_SRC := src/clickid_detect.cpp src/hdmi_test.cpp   # <--- added
+CPP_SRC := src/clickid_detect.cpp src/hdmi_test.cpp
 
 # Header files
 INC := $(wildcard include/*.h)
@@ -20,7 +20,7 @@ CFLAGS := $(CFLAGS_FOR_BUILD) -O3 -W -Wall -Wwrite-strings -I./include
 CXXFLAGS := -O3 -Wall -I./include
 
 # Targets
-all: beagle-tester clickid_detect hdmi_test          # <--- added
+all: beagle-tester clickid_detect hdmi_test
 
 beagle-tester: $(SRC_C) $(CLICK_TESTS) $(INC)
 	$(CC) -DVERSION=\"${GIT_VERSION}\" $(CFLAGS) $(SRC_C) $(CLICK_TESTS) -o beagle-tester
@@ -28,20 +28,20 @@ beagle-tester: $(SRC_C) $(CLICK_TESTS) $(INC)
 clickid_detect: src/clickid_detect.cpp
 	$(CXX) $(CXXFLAGS) src/clickid_detect.cpp -o clickid_detect
 
-hdmi_test: src/hdmi_test.cpp                        # <--- new rule
+hdmi_test: src/hdmi_test.cpp
 	$(CXX) $(CXXFLAGS) src/hdmi_test.cpp -o hdmi_test `pkg-config --cflags --libs opencv4`
 
 images:
 	$(MAKE) -C images
 
 clean:
-	$(RM) -f beagle-tester clickid_detect hdmi_test   # <--- added
+	$(RM) -f beagle-tester clickid_detect hdmi_test
 
 install:
 	$(INSTALL) -m 755 -d $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 700 beagle-tester $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 700 clickid_detect $(DESTDIR)$(prefix)/sbin
-	$(INSTALL) -m 700 hdmi_test $(DESTDIR)$(prefix)/sbin     # <--- added
+	$(INSTALL) -m 700 hdmi_test $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 744 bb-connect-ap $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 744 beagle-tester-open.sh $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 744 beagle-tester-close.sh $(DESTDIR)$(prefix)/sbin

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 # Source file lists
 SRC_C := $(wildcard src/*.c)
 CLICK_TESTS := $(wildcard click_tests/*.c)
-CPP_SRC := src/clickid_detect.cpp
+CPP_SRC := src/clickid_detect.cpp src/hdmi_test.cpp   # <--- added
 
 # Header files
 INC := $(wildcard include/*.h)
@@ -20,24 +20,28 @@ CFLAGS := $(CFLAGS_FOR_BUILD) -O3 -W -Wall -Wwrite-strings -I./include
 CXXFLAGS := -O3 -Wall -I./include
 
 # Targets
-all: beagle-tester clickid_detect
+all: beagle-tester clickid_detect hdmi_test          # <--- added
 
 beagle-tester: $(SRC_C) $(CLICK_TESTS) $(INC)
 	$(CC) -DVERSION=\"${GIT_VERSION}\" $(CFLAGS) $(SRC_C) $(CLICK_TESTS) -o beagle-tester
 
-clickid_detect: $(CPP_SRC)
-	$(CXX) $(CXXFLAGS) $(CPP_SRC) -o clickid_detect
+clickid_detect: src/clickid_detect.cpp
+	$(CXX) $(CXXFLAGS) src/clickid_detect.cpp -o clickid_detect
+
+hdmi_test: src/hdmi_test.cpp                        # <--- new rule
+	$(CXX) $(CXXFLAGS) src/hdmi_test.cpp -o hdmi_test `pkg-config --cflags --libs opencv4`
 
 images:
 	$(MAKE) -C images
 
 clean:
-	$(RM) -f beagle-tester clickid_detect
+	$(RM) -f beagle-tester clickid_detect hdmi_test   # <--- added
 
 install:
 	$(INSTALL) -m 755 -d $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 700 beagle-tester $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 700 clickid_detect $(DESTDIR)$(prefix)/sbin
+	$(INSTALL) -m 700 hdmi_test $(DESTDIR)$(prefix)/sbin     # <--- added
 	$(INSTALL) -m 744 bb-connect-ap $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 744 beagle-tester-open.sh $(DESTDIR)$(prefix)/sbin
 	$(INSTALL) -m 744 beagle-tester-close.sh $(DESTDIR)$(prefix)/sbin

--- a/src/beagle-tester.c
+++ b/src/beagle-tester.c
@@ -31,6 +31,7 @@
 #include <rc/time.h>
 #endif
 
+#include <stdlib.h>
 #include "common.h"
 void do_fill_screen(struct fb_info *fb_info, int pattern);
 void draw_pixel(struct fb_info *fb_info, int x, int y, unsigned color);
@@ -486,6 +487,19 @@ void beagle_test(const char *scan_value)
 	beagle_notice("tester", "$Id$");
 #endif
 
+    /********************************************/
+    /**  Handle HDMITEST Condition     **/
+    /********************************************/
+
+    if (strcmp(scan_value, "HDMITEST") == 0) {
+        int r = system("/usr/sbin/hdmi_test");
+        beagle_notice("hdmi", r == 0 ? "pass" : "fail");
+        fail = (r != 0);
+        run = 0;
+        memset(scan_value, 0, sizeof(scan_value));
+        continue;
+    }
+
 
     /********************************************/
     /**  Handle MKB001 barcode scan     **/
@@ -674,6 +688,15 @@ void beagle_test(const char *scan_value)
 	fflush(stderr);
 	r = system(str);
 	beagle_notice("usb dev", r ? "fail" : "pass");
+	// newly added: HDMI Tests
+	const char *model = get_device_model();
+    if (strstr(model, "BeagleBone Black") || strstr(model, "BeagleBoard") ||
+        strstr(model, "X15") || strstr(model, "AI")) {
+
+        int r = system("/usr/sbin/hdmi_test");
+        beagle_notice("hdmi", r == 0 ? "pass" : "fail");
+        fail |= (r != 0);
+    }
 
 	// if BeagleBoard-xM
 	if(!strcmp(model, MODEL_XM)) {

--- a/src/beagle-tester.c
+++ b/src/beagle-tester.c
@@ -494,10 +494,7 @@ void beagle_test(const char *scan_value)
     if (strcmp(scan_value, "HDMITEST") == 0) {
         int r = system("/usr/sbin/hdmi_test");
         beagle_notice("hdmi", r == 0 ? "pass" : "fail");
-        fail = (r != 0);
-        run = 0;
-        memset(scan_value, 0, sizeof(scan_value));
-        continue;
+        exit(r != 0);
     }
 
 
@@ -690,12 +687,12 @@ void beagle_test(const char *scan_value)
 	beagle_notice("usb dev", r ? "fail" : "pass");
 	// newly added: HDMI Tests
 	const char *model = get_device_model();
-    if (strstr(model, "BeagleBone Black") || strstr(model, "BeagleBoard") ||
-        strstr(model, "X15") || strstr(model, "AI")) {
+	if (strstr(model, "BeagleBone Black") || strstr(model, "BeagleBoard") ||
+    strstr(model, "X15") || strstr(model, "AI")) {
 
-        int r = system("/usr/sbin/hdmi_test");
-        beagle_notice("hdmi", r == 0 ? "pass" : "fail");
-        fail |= (r != 0);
+    int r = system("/usr/sbin/hdmi_test");
+    beagle_notice("hdmi", r == 0 ? "pass" : "fail");
+    fail |= (r != 0);
     }
 
 	// if BeagleBoard-xM

--- a/src/beagle-tester.c
+++ b/src/beagle-tester.c
@@ -686,7 +686,7 @@ void beagle_test(const char *scan_value)
 	r = system(str);
 	beagle_notice("usb dev", r ? "fail" : "pass");
 	// newly added: HDMI Tests
-	const char *model = get_device_model();
+	//const char *model = get_device_model();
 	if (strstr(model, "BeagleBone Black") || strstr(model, "BeagleBoard") ||
     strstr(model, "X15") || strstr(model, "AI")) {
 

--- a/src/hdmi_test.cpp
+++ b/src/hdmi_test.cpp
@@ -1,4 +1,3 @@
-// File: src/hdmi_test.cpp
 
 #include <opencv2/opencv.hpp>
 #include <iostream>

--- a/src/hdmi_test.cpp
+++ b/src/hdmi_test.cpp
@@ -1,0 +1,72 @@
+// File: src/hdmi_test.cpp
+
+#include <opencv2/opencv.hpp>
+#include <iostream>
+#include <string>
+#include <chrono>
+
+bool isColorful(const cv::Mat& frame) {
+    cv::Mat hsv;
+    cv::cvtColor(frame, hsv, cv::COLOR_BGR2HSV);
+
+    cv::Scalar lower_red1(0, 100, 100), upper_red1(10, 255, 255);
+    cv::Scalar lower_red2(160, 100, 100), upper_red2(180, 255, 255);
+    cv::Scalar lower_blue(100, 100, 100), upper_blue(130, 255, 255);
+    cv::Scalar lower_green(40, 100, 100), upper_green(70, 255, 255);
+
+    cv::Mat mask_red1, mask_red2, mask_blue, mask_green;
+    cv::inRange(hsv, lower_red1, upper_red1, mask_red1);
+    cv::inRange(hsv, lower_red2, upper_red2, mask_red2);
+    cv::inRange(hsv, lower_blue, upper_blue, mask_blue);
+    cv::inRange(hsv, lower_green, upper_green, mask_green);
+
+    cv::Mat mask_red = mask_red1 | mask_red2;
+
+    int total_pixels = cv::countNonZero(mask_red) +
+                       cv::countNonZero(mask_blue) +
+                       cv::countNonZero(mask_green);
+
+    return total_pixels > 5000;
+}
+
+int main(int argc, char** argv) {
+    bool save_frame = (argc > 1 && std::string(argv[1]) == "-s");
+
+    cv::VideoCapture cap("/dev/video0", cv::CAP_V4L2);
+    if (!cap.isOpened()) {
+        std::cerr << "Error: Could not open /dev/video0\n";
+        return 1;
+    }
+
+    cap.set(cv::CAP_PROP_FRAME_WIDTH, 640);
+    cap.set(cv::CAP_PROP_FRAME_HEIGHT, 480);
+    cap.set(cv::CAP_PROP_FPS, 5);
+
+    std::cout << "Waiting for colorful activity (for up to 20 seconds)...\n";
+
+    auto start_time = std::chrono::steady_clock::now();
+    cv::Mat frame;
+
+    while (true) {
+        cap >> frame;
+        if (frame.empty()) continue;
+
+        if (isColorful(frame)) {
+            std::cout << "Colorful activity detected!\n";
+            if (save_frame) cv::imwrite("detected_frame.jpg", frame);
+            cap.release();
+            return 0;
+        }
+
+        if (std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - start_time).count() >= 20) {
+            std::cout << "Timeout: No color detected in 20 seconds.\n";
+            break;
+        }
+
+        cv::waitKey(200);
+    }
+
+    cap.release();
+    return 1;
+}


### PR DESCRIPTION
<html><head></head><body><h1>HDMI Output Validation Test (<code inline="">HDMITEST</code>)</h1>
<h2> Overview</h2>
<p>This feature adds a new HDMI signal validation test to the <code inline="">beagle-tester</code> framework. It captures frames from a connected HDMI capture device (e.g., USB HDMI grabber) and verifies the presence of a colorful display (such as a colorbar test pattern) as an indicator of working HDMI output.</p>
<hr>
<h2> Features</h2>
<ul>
<li>
<p> Integrated into standard board test sequence for HDMI-capable boards</p>
</li>
<li>
<p> Can be manually invoked via CLI using <code inline="">beagle-tester HDMITEST</code></p>
</li>
<li>
<p> Captures up to 20 seconds of frames from <code inline="">/dev/video0</code> using OpenCV</p>
</li>
<li>
<p> Detects red, green, or blue color activity</p>
</li>
<li>
<p> Outputs result using <code inline="">beagle_notice("hdmi", "pass/fail")</code></p>
</li>
<li>
<p> Returns 0 on pass, 1 on failure</p>
</li>
</ul>
<hr>
<h2> Supported Boards</h2>
<p>HDMI test is executed only on the following boards:</p>

Board | Status
-- | --
BeagleBone Black |  Yes
BeagleBone Black Wireless | Yes
BeagleBoard-xM |  Yes
BeagleBoard-X15 |  Yes
BeagleBone AI |  Yes


<hr>
<h2> Usage</h2>
<h3>1. Manual CLI Invocation</h3>
<pre><code class="language-bash">beagle-tester HDMITEST
</code></pre>
<p>Optional flag to save detected frame:</p>
<pre><code class="language-bash">beagle-tester HDMITEST -s
</code></pre>
<h3>2. Automatic Invocation</h3>
<p>The HDMI test is now automatically executed within the normal board test sequence (in <code inline="">beagle_test()</code>) <strong>after USB and network tests</strong>, but only on HDMI-capable boards.</p>
<hr>
<h2>🛠️ Implementation</h2>
<ul>
<li>
<p><strong>New source file:</strong> <code inline="">src/hdmi_test.cpp</code></p>
</li>
<li>
<p>Uses OpenCV with V4L2 backend to capture from <code inline="">/dev/video0</code></p>
</li>
<li>
<p>Color activity detection based on red, green, and blue HSV masks</p>
</li>
<li>
<p>Added to build system via <code inline="">Makefile</code> as <code inline="">hdmi_test</code></p>
</li>
<li>
<p>Installed to <code inline="">/usr/sbin/hdmi_test</code></p>
</li>
</ul>
<h3>Sample Output</h3>
<pre><code class="language-bash">Waiting for colorful activity (for up to 20 seconds)...
Colorful activity detected!
PASS
</code></pre>
<p>or</p>
<pre><code class="language-bash">Waiting for colorful activity (for up to 20 seconds)...
Timeout: No color detected in 20 seconds.
FAIL
</code></pre>
<hr>
<h2> Build Instructions</h2>
<p>Ensure OpenCV is installed:</p>
<pre><code class="language-bash">sudo apt-get install libopencv-dev
</code></pre>
<p>Then build and install:</p>
<pre><code class="language-bash">make clean
make
sudo make install
</code></pre>
<hr>
<h2> Notes</h2>
<ul>
<li>
<p>You must have a USB HDMI capture device exposed as <code inline="">/dev/video0</code>.</p>
</li>
<li>
<p>Ensure a test pattern (e.g., colorbar) is active on the HDMI output during testing.</p>
</li>
<li>
<p>The HDMI test will be skipped silently for boards without HDMI hardware support.</p>
</li>
</ul>
<hr></body></html>